### PR TITLE
Added missing UnityEngine.Assertions namespace for Unity

### DIFF
--- a/Source/NetStack.Serialization/BitBuffer.cs
+++ b/Source/NetStack.Serialization/BitBuffer.cs
@@ -40,9 +40,14 @@
  */
 
 using System;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+
+#if ENABLE_MONO || ENABLE_IL2CPP
+using UnityEngine.Assertions;
+#else
+using System.Diagnostics;
+#endif
 
 namespace NetStack.Serialization {
 	public class BitBuffer {


### PR DESCRIPTION
Added the missing UnityEngine.Assertions namespace for Unity which caused the "CS0103: The name 'Assert' does not exist in the current context" error.